### PR TITLE
1.修复res://协议首次启动地址不正确的问题;2.修复设置状态栏无效的问题;3修复iOS10+上收到推送消息后前端无法获取设置的回调函数和推送数据.

### DIFF
--- a/webkitCorePalm/Classes/engine/ACEBrowserView.m
+++ b/webkitCorePalm/Classes/engine/ACEBrowserView.m
@@ -713,6 +713,12 @@ const CGFloat loadingVisibleHeight = 60.0f;
     
     BOOL isStatusBarHidden = [[[NSBundle mainBundle].infoDictionary valueForKey:@"UIStatusBarHidden"] boolValue];
     [self loadUEXScript];
+    
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:@"showStatusBar"]) {
+        
+        isStatusBarHidden = [[[NSUserDefaults standardUserDefaults] objectForKey:@"showStatusBar"] boolValue];
+    }
+    
     initStr = [[NSString alloc] initWithFormat:@"uexWidgetOne.platformVersion = \'%@\';uexWidgetOne.isFullScreen = %d;uexWidgetOne.iOS7Style = %d;", [[UIDevice currentDevice] systemVersion],isStatusBarHidden,iOS7Style];
     [self stringByEvaluatingJavaScriptFromString:initStr];
     

--- a/webkitCorePalm/Classes/engine/universalex/EUExWidget.m
+++ b/webkitCorePalm/Classes/engine/universalex/EUExWidget.m
@@ -48,6 +48,7 @@
 #import "ACEUINavigationController.h"
 #import "ACESubwidgetManager.h"
 
+#import <UserNotifications/UserNotifications.h>
 
 
 #define UEX_EXITAPP_ALERT_TITLE @"退出提示"
@@ -88,7 +89,12 @@ typedef NS_ENUM(NSInteger,uexWidgetPushStatus){
     [self onReceivePushNotification:userInfo];
 }
 
-
++ (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)())completionHandler{
+    
+    NSDictionary * userInfo = response.notification.request.content.userInfo;
+    [self onReceivePushNotification:userInfo];
+    
+}
 
 + (void)onReceivePushNotification:(NSDictionary *)userInfo{
     if (!userInfo) {

--- a/webkitCorePalm/Classes/engine/universalex/EUExWindow.m
+++ b/webkitCorePalm/Classes/engine/universalex/EUExWindow.m
@@ -3195,14 +3195,17 @@ static NSTimeInterval getAnimationDuration(NSNumber * durationMillSeconds){
 - (void)hideStatusBar:(NSArray *)inArgument {
     self.EBrwView.meBrwCtrler.shouldHideStatusBarNumber = @(YES);
     [self.EBrwView.meBrwCtrler.aceNaviController setNeedsStatusBarAppearanceUpdate];
+    [[NSUserDefaults standardUserDefaults] setObject:@"1" forKey:@"showStatusBar"];
 
     
 }
 
 - (void)showStatusBar:(NSArray *)inArgument {
+    
     self.EBrwView.meBrwCtrler.shouldHideStatusBarNumber = @(NO);
     [self.EBrwView.meBrwCtrler.aceNaviController setNeedsStatusBarAppearanceUpdate];
-    
+    [[NSUserDefaults standardUserDefaults] setObject:@"0" forKey:@"showStatusBar"];
+
 }
 
 //设置状态条上字体的颜色

--- a/webkitCorePalm/Classes/widgetone/WWidget.m
+++ b/webkitCorePalm/Classes/widgetone/WWidget.m
@@ -77,7 +77,18 @@
             wgtPath = [wgtPath substringFromIndex:range1.location + range1.length];
             //wgtPath = [wgtPath stringByAppendingString:self.appId];
             wgtPath = [wgtPath stringByAppendingPathComponent:self.appId];
-
+            
+        }else{
+            
+            subWidgetIdentifier = @"widget/plugin/";
+            NSRange range = [self.indexUrl rangeOfString:subWidgetIdentifier];
+            if (range.location != NSNotFound) {
+                wgtPath = [wgtPathString substringToIndex:range.location+range.length];
+                NSRange range1 = [wgtPath rangeOfString:@"file://"];
+                wgtPath = [wgtPath substringFromIndex:range1.location + range1.length];
+                wgtPath = [wgtPath stringByAppendingPathComponent:self.appId];
+                
+            }
         }
     }
     NSFileManager *fManager = [NSFileManager defaultManager];


### PR DESCRIPTION
1.修复res://协议首次启动地址不正确的问题;2.修复设置状态栏无效的问题;3修复iOS10+上收到推送消息后前端无法获取设置的回调函数和推送数据.