### PR TITLE
修改Pushv4的相关逻辑，修复推送上报的bug

### DIFF
--- a/webkitCorePalm/Classes/base/EUtility.h
+++ b/webkitCorePalm/Classes/base/EUtility.h
@@ -326,6 +326,7 @@ extern NSString * const cUexPluginCallbackInFrontWindow;
 + (UIImage *)imageByScalingAndCroppingForSize:(UIImage *)image;
 + (NSString*)LogServerIp:(EBrowserView*)inBrwView;
 + (NSString*)md5SoftToken;
++ (NSString *)getTenantIdentifier;
 + (NSString*)getCachePath:(NSString*)fileName;
 @end
 

--- a/webkitCorePalm/Classes/base/EUtility.m
+++ b/webkitCorePalm/Classes/base/EUtility.m
@@ -529,6 +529,24 @@ callbackWithFunctionKeyPath:(NSString *)JSKeyPath
     
     return softToken;
 }
+/**
+ 获取租户标识逻辑
+ */
++(NSString *)getTenantIdentifier{
+    NSString *tenantId = @"";
+    NSString *useAppCanEMMTenantID = ((WidgetOneDelegate *)[[UIApplication sharedApplication] delegate]).useAppCanEMMTenantID;
+    if ([useAppCanEMMTenantID isKindOfClass:[NSString class]]&&[useAppCanEMMTenantID length]>0) {
+        tenantId = useAppCanEMMTenantID;
+    }else {
+        //打包时未设置，则使用EMM设置的租户标识
+        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+        NSString *tenantIdEmmStr = [defaults objectForKey:@"tenantAccount"];
+        if ([tenantIdEmmStr isKindOfClass:[NSString class]]&&[tenantIdEmmStr length]>0) {
+            tenantId = tenantIdEmmStr;
+        }
+    }
+    return tenantId;
+}
 +(NSString*)getCachePath:(NSString*)fileName{
     return [BUtility getCachePath:fileName];
 }

--- a/webkitCorePalm/Classes/engine/universalex/EUExWidget.m
+++ b/webkitCorePalm/Classes/engine/universalex/EUExWidget.m
@@ -207,11 +207,11 @@ static BOOL isAppLaunchedByPush = NO;
         return;
     }
     
-    if ([AppCanEngine.configuration.useBindUserPushURL rangeOfString:@"push/gateway"].location == NSNotFound) {//URL里包含“push/gateway”的才是4.0后台，否则没有清零逻辑。(暂时以这个区分判断)
+    if ([AppCanEngine.configuration.useBindUserPushURL rangeOfString:@"gateway"].location == NSNotFound) {//URL里包含“gateway”的才是v4后台，否则没有清零逻辑。
         return;
     }
     
-    NSString *urlStr =[NSString stringWithFormat:@"%@/4.0/count/",AppCanEngine.configuration.useBindUserPushURL];
+    NSString *urlStr =[NSString stringWithFormat:@"%@4.0/count/",AppCanEngine.configuration.useBindUserPushURL];
     NSURL *requestUrl = [NSURL URLWithString:urlStr];
     NSString *appid = [WWidgetMgr sharedManager].mainWidget.appId ?: @"";
     NSString *appkey = [BUtility appKey] ? [BUtility appKey] : @"";
@@ -796,7 +796,7 @@ static BOOL isAppLaunchedByPush = NO;
 }
 - (void)delPushInfo:(NSMutableArray *)inArguments {
     
-    if ([AppCanEngine.configuration.useBindUserPushURL rangeOfString:@"push"].location == NSNotFound) {
+    if ([AppCanEngine.configuration.useBindUserPushURL rangeOfString:@"push"].location == NSNotFound &&[AppCanEngine.configuration.useBindUserPushURL rangeOfString:@"mms"].location == NSNotFound) {
         
         NSString *appId = self.EBrwView.meBrwCtrler.mwWgtMgr.mainWidget.appId;
         NSString *appkey = [BUtility appKey];
@@ -822,7 +822,7 @@ static BOOL isAppLaunchedByPush = NO;
         //租户标识
         NSString *tenantMark = [EUtility getTenantIdentifier];
         
-        if (!deviceToken || ![deviceToken isEqualToString:@"(null)"]) {
+        if (!deviceToken || [deviceToken isEqualToString:@"(null)"]) {
             deviceToken = @"";
         }
         
@@ -931,6 +931,9 @@ static BOOL isAppLaunchedByPush = NO;
         
         //设备标识 deviceToken
         NSString *deviceToken = [dict objectForKey:@"deviceToken"];
+        if (!deviceToken || [deviceToken isEqualToString:@"(null)"]) {
+            deviceToken = @"";
+        }
         //租户标识
         NSString *tenantMark = [EUtility getTenantIdentifier];
         


### PR DESCRIPTION
1. Pushv4独立绑定接口新增请求来源、类型、租户等字段，以便后端跟踪问题;
2. 修复Pushv4角标上报的判断条件bug以及绑定相关的几个bug