### PR TITLE
修复补丁包升级合并时文件夹会导致丢失原有文件而可能导致启动黑屏的问题

### DIFF
--- a/AppCanEngine/Changelog.plist
+++ b/AppCanEngine/Changelog.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>4.1.11</key>
+	<array>
+		<string>修复补丁包合并时文件夹会导致丢失原有文件而可能导致启动黑屏的问题</string>
+	</array>
 	<key>4.1.10</key>
 	<array>
 		<string>publishChannelNotification兼容3.0</string>

--- a/webkitCorePalm/Classes/widgetone/ACEWidgetUpdateUtility.m
+++ b/webkitCorePalm/Classes/widgetone/ACEWidgetUpdateUtility.m
@@ -478,8 +478,15 @@ static NSString *const ACEWidgetVersionUserDefaultsKey =            @"AppCanWidg
         BOOL isDirectory = [FileManager fileExistsAtPath:srcFullPath isDirectory:&isDirectory] && isDirectory;
         
 
-        if (isDirectory && (![FileManager createDirectoryAtPath:potentialDstPath withIntermediateDirectories:YES attributes:nil error:&err] || err)) {
-            return NO;
+        if (isDirectory) {
+            if(![FileManager createDirectoryAtPath:potentialDstPath withIntermediateDirectories:YES attributes:nil error:&err] || err){
+                //return YES if the directory was created, YES if createIntermediates is set and the directory already exists, or NO if an error occurred.
+                return NO;
+            }else{
+                if(![self mergeFolderAtPath:srcFullPath intoPath:potentialDstPath error:&err]){
+                    return NO;
+                }
+            }
         }else {
             if ([FileManager fileExistsAtPath:potentialDstPath] && (![FileManager removeItemAtPath:potentialDstPath error:&err] || err)) {
                 return NO;


### PR DESCRIPTION
修复补丁包升级合并时文件夹会导致丢失原有文件而可能导致启动黑屏的问题