### PR TITLE
4.1.13：修复子应用升级、上报的问题，优化主应用补丁升级逻辑

### DIFF
--- a/AppCanEngine/Changelog.plist
+++ b/AppCanEngine/Changelog.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>4.1.13</key>
+	<array>
+		<string>优化主应用补丁包更新速度，减少8badf00d崩溃几率</string>
+		<string>修复当子应用与主应用版本号相同时，会导致子应用无法正常升级(版本号不变)的bug</string>
+		<string>修复当数据统计插件存在时，EMM插件不会触发子应用的启动上报的bug</string>
+	</array>
 	<key>4.1.12</key>
 	<array>
 		<string>修复窗口打开动画问题</string>

--- a/AppCanEngine/Info.plist
+++ b/AppCanEngine/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.10</string>
+	<string>4.1.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4.1.10</string>
+	<string>4.1.13</string>
 </dict>
 </plist>

--- a/webkitCorePalm/Classes/engine/universalex/EUExWidget.m
+++ b/webkitCorePalm/Classes/engine/universalex/EUExWidget.m
@@ -405,7 +405,7 @@ static BOOL isAppLaunchedByPush = NO;
     
     //子widget启动上报代码
     //过滤掉无appkey的子应用上报(plugin类型)
-    if (self.EBrwView.meBrwCtrler.isAppCanRootViewController || !inAppkey || inAppkey.length == 0) {
+    if (!inAppkey || inAppkey.length == 0) {
         return;
     }
     id analysisObject = ACEAnalysisObject();
@@ -415,7 +415,12 @@ static BOOL isAppLaunchedByPush = NO;
     [analysisObject ac_invoke:@"setWidgetVersion:" arguments:ACArgsPack(wgtObj.ver)];
     [analysisObject ac_invoke:@"startWithChildAppKey:" arguments:ACArgsPack(inAppkey)];
     
+    id emmObject = ACEEMMObject();
     
+    [emmObject ac_invoke:@"setAppChannel:" arguments:ACArgsPack(wgtObj.channelCode)];
+    [emmObject ac_invoke:@"setAppId:" arguments:ACArgsPack(wgtObj.appId)];
+    [emmObject ac_invoke:@"setWidgetVersion:" arguments:ACArgsPack(wgtObj.ver)];
+    [emmObject ac_invoke:@"startWithChildAppKey:" arguments:ACArgsPack(inAppkey)];
 
 }
 

--- a/webkitCorePalm/Classes/plugin/DataAnalysisInfo.h
+++ b/webkitCorePalm/Classes/plugin/DataAnalysisInfo.h
@@ -13,6 +13,7 @@
 
 
 APPCAN_EXPORT id ACEAnalysisObject();
+APPCAN_EXPORT id ACEEMMObject();
 
 @interface DataAnalysisInfo : NSObject
 

--- a/webkitCorePalm/Classes/plugin/DataAnalysisInfo.m
+++ b/webkitCorePalm/Classes/plugin/DataAnalysisInfo.m
@@ -22,6 +22,22 @@ id ACEAnalysisObject(){
     return obj;
 }
 
+/**
+ 用于子应用启动时传递事件给uexEMM插件的对象
+
+ */
+id ACEEMMObject(){
+    static id obj = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class emmClass = NSClassFromString(@"UexEMMAppCanAnalysis");
+        if (!emmClass) {
+            return;
+        }
+        obj = [[emmClass alloc] init];
+    });
+    return obj;
+}
 
 @implementation DataAnalysisInfo
 + (NSDictionary *)getAppInfoWithCurWgt:(WWidget *)curWgt{

--- a/webkitCorePalm/Classes/widgetone/ACEWidgetUpdateUtility.m
+++ b/webkitCorePalm/Classes/widgetone/ACEWidgetUpdateUtility.m
@@ -271,9 +271,9 @@ static NSString *const ACEWidgetVersionUserDefaultsKey =            @"AppCanWidg
     if ([FileManager fileExistsAtPath:newWidgetPath]) {
         [FileManager removeItemAtPath:newWidgetPath error:nil];
     }
-    
-    if (![FileManager copyItemAtPath:tmpWidgetPath toPath:newWidgetPath error:&error]) {
-        ACLogError(@"copy tmpFolder to newWidgetPath failed: %@",error.localizedDescription);
+    //原copy改为move，缩短主应用补丁包更新时间，减少8badf00d崩溃几率。
+    if (![FileManager moveItemAtPath:tmpWidgetPath toPath:newWidgetPath error:&error]) {
+        ACLogError(@"move tmpFolder to newWidgetPath failed: %@",error.localizedDescription);
         return ACEWidgetUpdateResultError;
     }
     if (![oldWidgetPath isEqualToString:newWidgetPath] && ![FileManager removeItemAtPath:oldWidgetPath error:&error]) {

--- a/webkitCorePalm/Classes/widgetone/WWidgetMgr.m
+++ b/webkitCorePalm/Classes/widgetone/WWidgetMgr.m
@@ -289,7 +289,9 @@ NSString * webappShowAactivety;
     }
     //热修复路径
     
-    NSString *mVer = [ACEConfigXML ACEWidgetConfigXML][@"version"] ?: @"";
+    NSString *mVer = newVersion;
+    
+    //比对缓存的子应用信息与新的子应用信息的version，若相同，则直接用缓存；不相同，则更新信息
     if ([wgtObj.ver isEqualToString:mVer]) {
         return wgtObj;
     }


### PR DESCRIPTION

  |   | 修复当数据统计插件存在时，子应用启动时EMM插件不会自动上报的bug |   |   | 64d19ed
-- | -- | -- | -- | -- | --
  |   | 修复当子应用和主应用的版本号相同时，会导致子应用无法正常升级（版本号不变）的bug。 |   |   | 903e7b0
  |   | 优化主应用补丁包更新速度，减少8badf00d崩溃几率。 |   |   | 463de7c
  |   | 更新版本号为4.1.13 |   |   | 3d125d2

